### PR TITLE
Add Swipe Down to Refresh

### DIFF
--- a/lib/screens/homescreen_screen.dart
+++ b/lib/screens/homescreen_screen.dart
@@ -1,20 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:provider/provider.dart';
 import 'package:xnmoapp/screens/splash_screen.dart';
 import 'package:xnmoapp/widgets/activity_card.dart';
 import 'package:xnmoapp/widgets/status_card.dart';
+import 'package:xnmoapp/view_models/status_view_model.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
   void _logout(BuildContext context) async {
     await FirebaseAuth.instance.signOut();
-
     Navigator.pushAndRemoveUntil(
       context,
       MaterialPageRoute(builder: (context) => const SplashScreen()),
           (route) => false,
     );
+  }
+
+  Future<void> _refreshData(BuildContext context) async {
+    await Future.wait([
+      Provider.of<StatusViewModel>(context, listen: false).fetchLastStatus(),
+    ]);
   }
 
   @override
@@ -30,11 +37,15 @@ class HomeScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: ListView(
-        children: [
-          StatusCard(),
-          ActivityCard(),
-        ],
+      body: RefreshIndicator(
+        onRefresh: () => _refreshData(context),
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: const [
+            StatusCard(),
+            ActivityCard(),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION

## Summary  
This PR adds **swipe-down-to-refresh** functionality across key screens, allowing users to manually refresh data when needed.  

This closes https://github.com/ImadMashhood/xnmo/issues/2  

## What's Changed  
- Implemented **RefreshIndicator** for swipe-to-refresh behavior.  
- Applied pull-to-refresh functionality 
- Added UI feedback with loading indicators during refresh.  
- Ensured smooth user experience with a responsive refresh animation.  

## Implementation Details  
- Used Flutter’s built-in `RefreshIndicator` to handle pull-to-refresh gestures.  
- Integrated with the existing ViewModel structure to trigger data reloads.  

## Additional Notes  

<details>
  <summary>Click to expand</summary>

[Screen_recording_20250220_183843.webm](https://github.com/user-attachments/assets/9768888e-021e-4717-956d-c86b7d004900)
</details>

