### PR TITLE
Setup Admin Page

### DIFF
--- a/lib/repositories/firestore_repository.dart
+++ b/lib/repositories/firestore_repository.dart
@@ -20,6 +20,20 @@ class FirestoreRepository {
     await _firestoreService.addTimestamp(status, position.latitude, position.longitude);
   }
 
+  Stream<List<WorkLog>> streamActivityLogsForUser(String userId) {
+    return _firestoreService.getActivityLogsForUser(userId).map((snapshot) {
+      return snapshot.docs.map((doc) {
+        var data = doc.data() as Map<String, dynamic>;
+        return WorkLog(
+          date: (data['timestamp'] as Timestamp).toDate(),
+          status: data['status'],
+          latitude: data['location']?['lat'],
+          longitude: data['location']?['lon'],
+        );
+      }).toList();
+    });
+  }
+
   Stream<List<WorkLog>> streamActivityLogs() {
     return _firestoreService.streamActivityLogs().map((snapshot) {
       return snapshot.docs.map((doc) {

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -18,7 +18,7 @@ class _SignupScreenState extends State<SignupScreen> {
   final TextEditingController _passwordController = TextEditingController();
   final TextEditingController _confirmPasswordController = TextEditingController();
 
-  bool _isLoading = false; // Tracks loading state
+  bool _isLoading = false;
 
   Future<void> _signUp() async {
     if (_emailController.text.trim().isEmpty || _passwordController.text.trim().isEmpty) {

--- a/lib/screens/user_work_activity_screen.dart
+++ b/lib/screens/user_work_activity_screen.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:syncfusion_flutter_calendar/calendar.dart';
+import 'package:xnmoapp/objects/work_data_source.dart';
+import 'package:xnmoapp/objects/work_logs.dart';
+import 'package:xnmoapp/view_models/user_activity_view_model.dart';
+
+class UserWorkActivityScreen extends StatelessWidget {
+  final String userId;
+  final String email;
+
+  const UserWorkActivityScreen({super.key, required this.userId, required this.email});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => UserActivityViewModel(userId),
+      child: Scaffold(
+        appBar: AppBar(title: Text("Activity for $email")),
+        body: Consumer<UserActivityViewModel>(
+          builder: (context, viewModel, child) {
+            if (viewModel.isLoading) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            return Column(
+              children: [
+                SfCalendar(
+                  view: CalendarView.month,
+                  dataSource: WorkDataSource(viewModel.workLogs),
+                  monthCellBuilder: (context, details) => _buildMonthCell(details, viewModel.workLogs),
+                  onTap: (details) {
+                    if (details.date != null) {
+                      viewModel.selectedDate = details.date;
+                      viewModel.notifyListeners();
+                    }
+                  },
+                ),
+                if (viewModel.selectedDate != null)
+                  _buildExpandedView(viewModel),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildExpandedView(UserActivityViewModel viewModel) {
+    final logs = viewModel.getLogsForDate(viewModel.selectedDate!);
+    final totalHours = viewModel.calculateTotalHours(logs);
+
+    return Expanded(
+      child: ListView(
+        padding: const EdgeInsets.all(12),
+        children: [
+          Text("Total Hours Worked: ${totalHours.toStringAsFixed(2)} hrs",
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          if (logs.isEmpty)
+            const Text("No logs for this day."),
+          ...logs.map((log) => _buildLogEntry(viewModel, log)).toList(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLogEntry(UserActivityViewModel viewModel, WorkLog log) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      color: Colors.grey[850],
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text("Status: ${log.status}", style: const TextStyle(fontWeight: FontWeight.bold)),
+            Text(DateFormat('h:mm a').format(log.date)),
+            const SizedBox(height: 8),
+            if (log.latitude != null && log.longitude != null)
+              viewModel.getMapWidget(log.latitude!, log.longitude!, 15),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMonthCell(MonthCellDetails details, List<WorkLog> logs) {
+    final hasLogs = logs.any((log) => _isSameDay(log.date, details.date));
+    return Container(
+      decoration: BoxDecoration(
+        color: hasLogs ? Colors.green[600] : Colors.transparent,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Center(
+        child: Text(
+          "${details.date.day}",
+          style: TextStyle(
+            color: hasLogs ? Colors.white : Colors.white,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+}

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -46,4 +46,13 @@ class FirestoreService {
         .orderBy('timestamp', descending: true)
         .snapshots();
   }
+
+  Stream<QuerySnapshot> getActivityLogsForUser(String userId) {
+    return _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('timestamps')
+        .orderBy('timestamp', descending: true)
+        .snapshots();
+  }
 }

--- a/lib/view_models/admin_view_model.dart
+++ b/lib/view_models/admin_view_model.dart
@@ -1,0 +1,39 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+class AdminViewModel extends ChangeNotifier {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  bool isLoading = true;
+  List<Map<String, dynamic>> users = [];
+
+  AdminViewModel() {
+    fetchUsers();
+  }
+
+  Future<void> fetchUsers() async {
+    isLoading = true;
+    notifyListeners();
+
+    try {
+      final currentUser = _auth.currentUser;
+      final snapshot = await _firestore.collection('users').get();
+
+      users = snapshot.docs
+          .where((doc) => doc.id != currentUser?.uid) // 👈 Exclude current user
+          .map((doc) {
+        final data = doc.data();
+        data['id'] = doc.id;
+        return data;
+      })
+          .toList();
+    } catch (e) {
+      users = [];
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/view_models/user_activity_view_model.dart
+++ b/lib/view_models/user_activity_view_model.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:xnmoapp/objects/work_logs.dart';
+import 'package:xnmoapp/repositories/firestore_repository.dart';
+import 'package:xnmoapp/repositories/map_repository.dart';
+import 'package:xnmoapp/enum/work_status_enum.dart';
+
+class UserActivityViewModel extends ChangeNotifier {
+  final FirestoreRepository _firestoreRepository = FirestoreRepository();
+  final MapRepository _mapRepository = MapRepository();
+
+  final String userId;
+
+  bool isLoading = true;
+  List<WorkLog> workLogs = [];
+  DateTime? selectedDate;
+
+  UserActivityViewModel(this.userId) {
+    _observeLogs();
+  }
+
+  void _observeLogs() {
+    _firestoreRepository.streamActivityLogsForUser(userId).listen((logs) {
+      workLogs = logs.map((log) {
+        return WorkLog(
+          date: log.date,
+          status: log.status.toWorkStatus().pastTenseDisplayName,
+          latitude: log.latitude,
+          longitude: log.longitude,
+        );
+      }).toList();
+
+      isLoading = false;
+      notifyListeners();
+    });
+  }
+
+  List<WorkLog> getLogsForDate(DateTime date) {
+    return workLogs.where((log) => _isSameDay(log.date, date)).toList();
+  }
+
+  double calculateTotalHours(List<WorkLog> logs) {
+    DateTime? clockIn;
+    DateTime? breakStart;
+    int totalMinutes = 0;
+    int breakMinutes = 0;
+
+    for (var log in logs) {
+      final status = log.status.toWorkStatus();
+
+      if (status == WorkStatus.clockIn) {
+        clockIn = log.date;
+      } else if (status == WorkStatus.clockOut && clockIn != null) {
+        totalMinutes += log.date.difference(clockIn).inMinutes;
+        clockIn = null;
+      } else if (status == WorkStatus.onBreak) {
+        breakStart = log.date;
+      } else if (status == WorkStatus.endBreak && breakStart != null) {
+        breakMinutes += log.date.difference(breakStart).inMinutes;
+        breakStart = null;
+      }
+    }
+
+    if (clockIn != null) {
+      totalMinutes += DateTime.now().difference(clockIn).inMinutes;
+    }
+
+    return (totalMinutes - breakMinutes) / 60.0;
+  }
+
+  Widget getMapWidget(double lat, double lon, int zoom) {
+    return _mapRepository.fetchMapWidget(lat, lon, zoom);
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+}

--- a/lib/widgets/admin_card.dart
+++ b/lib/widgets/admin_card.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:xnmoapp/reusable_components/expandable_card.dart';
+import 'package:xnmoapp/screens/user_work_activity_screen.dart';
+import 'package:xnmoapp/view_models/admin_view_model.dart';
+
+class AdminCard extends StatelessWidget {
+  const AdminCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => AdminViewModel(),
+      child: Consumer<AdminViewModel>(
+        builder: (context, viewModel, child) {
+          return ExpandableCard(
+            title: "Admin Panel",
+            child: viewModel.isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: viewModel.users.isEmpty
+                  ? [const Text("No users found.")]
+                  : viewModel.users.map((user) {
+                return ListTile(
+                  title: Text(user['email'] ?? 'Unknown'),
+                  subtitle: Text(user['isAdmin'] == true ? 'Admin' : 'User'),
+                  trailing: const Icon(Icons.chevron_right), // <- Chevron added here
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => UserWorkActivityScreen(
+                          userId: user['id'],
+                          email: user['email'] ?? '',
+                        ),
+                      ),
+                    );
+                  },
+                );
+              }).toList(),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary  
This PR introduces the Admin Panel, a new interface that allows admin users to view all registered users and inspect individual user activity.

This closes https://github.com/ImadMashhood/xnmo/issues/6
This closes https://github.com/ImadMashhood/xnmo/issues/3

## What's Changed  
- Added an AdminCard widget that lists all users in the database (excluding the current user).
- Clicking on a user navigates to a new UserWorkActivityScreen that displays their work logs.
- Integrated with existing MVVM structure via AdminViewModel and UserActivityViewModel.
- Each user in the list now includes a chevron icon to indicate interactivity.

## Implementation Details  

- Fetched users from Firestore via AdminViewModel, excluding the currently logged-in user.
- Attached navigation to UserWorkActivityScreen on list item tap.
- The UserWorkActivityScreen reuses the existing calendar-based UI from ActivityCard for consistency.
- Added document IDs to user data for dynamic routing and fetching.

## Additional Notes  

<details>
  <summary>Click to expand</summary>

![image](https://github.com/user-attachments/assets/d8b8b492-6a53-4d97-bbce-7e05bc86cb91)
![image](https://github.com/user-attachments/assets/c688f73c-2f83-4830-9757-c72a00e514a7)

</details>

